### PR TITLE
Ability to keep meta data if there are duplicate keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+Pods
+Podfile.lock
+.DS_Store
+xcuserdata
+

--- a/KFEpubKit/Sources/KFEpubParser.m
+++ b/KFEpubKit/Sources/KFEpubParser.m
@@ -114,7 +114,7 @@
         value = [[xmlElement attributeForName:@"full-path"] stringValue];
         count++;
     }
-
+    
     if (count == 1 && value)
     {
         return [baseURL URLByAppendingPathComponent:value];
@@ -196,12 +196,18 @@
     {
         DDXMLElement *metaNode = metaNodes[0];
         NSArray *metaElements = metaNode.children;
-
+        
         for (DDXMLElement* xmlElement in metaElements)
-        {
+        {            
             if ([self isValidNode:xmlElement])
             {
-                metaData[xmlElement.localName] = xmlElement.stringValue;
+                if (![metaData objectForKey:xmlElement.localName]) {
+                    metaData[xmlElement.localName] = xmlElement.stringValue;
+                }else{
+                    NSString * attributeString = [[[xmlElement attributes] firstObject] stringValue];
+                    NSString * metaDataKeyString = [NSString stringWithFormat:@"%@-%@", xmlElement.localName, attributeString];
+                    metaData[metaDataKeyString] = xmlElement.stringValue;
+                }
             }
         }
     }


### PR DESCRIPTION
Sample meta-data from an EPUB with this issue:
<dc:identifier opf:scheme="ISBN">9780316219259/dc:identifier
<dc:identifier opf:scheme="MOBI-ASIN">B00BWQW73E/dc:identifier
<dc:identifier id="uuid_id" opf:scheme="uuid">877a0722-d692-48f4-b491-40a0af0157e1/dc:identifier
<dc:identifier opf:scheme="calibre">877a0722-d692-48f4-b491-40a0af0157e1/dc:identifier

The current implementation of meta data will only return the last id (the calibre id) instead of all 4 entries.  I am appending the opf:scheme stringValue to make it a unique key.

Let me know if this requires any changes.  I can write a unit test if necessary and add this sample meta-data to the unit testing resources.
