### PR TITLE
letting delegate know if there are errors opening the book

### DIFF
--- a/KFEpubKit/Sources/KFEpubController.m
+++ b/KFEpubKit/Sources/KFEpubController.m
@@ -77,6 +77,13 @@
 {
     self.parser = [KFEpubParser new];
     NSURL *rootFile = [self.parser rootFileForBaseURL:self.destinationURL];
+    
+    if (!rootFile) {
+        NSError *error = [NSError errorWithDomain:KFEpubKitErrorDomain code:1 userInfo:@{NSLocalizedDescriptionKey: @"No root file"}];
+        [self.delegate epubController:self didFailWithError:error];
+        return;
+    }
+    
     _epubContentBaseURL = [rootFile URLByDeletingLastPathComponent];
     
     NSError *error = nil;
@@ -107,6 +114,11 @@
                 [self.delegate epubController:self didOpenEpub:self.contentModel];
             }
         }
+    }
+    else
+    {
+        NSError *error = [NSError errorWithDomain:KFEpubKitErrorDomain code:1 userInfo:@{NSLocalizedDescriptionKey: @"No document found"}];
+        [self.delegate epubController:self didFailWithError:error];
     }
 }
 


### PR DESCRIPTION
If the rootFileForBaseURL fails and returns a nil, the KFEpubKit logs a message but is silent to the delegate. 

I added calling delegate's didFailWithError to two cases where something has gone wrong.